### PR TITLE
Changed name field in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Copy issue link Bookmarklet",
+  "name": "copy-issue-link-bookmarklet",
   "version": "0.0.1",
   "description": "Copies a markdown link to the issue your viewing",
   "main": "dist/bookmark.js",


### PR DESCRIPTION
This resolves #1. After the change, `npm i` runs successfully.

```
$ npm i
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
copy-issue-link-bookmarklet@0.0.1 /Users/lowply/.ghq/github.com/lowply/copy-issue-link-bookmarklet
```